### PR TITLE
Add filter propagation

### DIFF
--- a/pages/file/index.html
+++ b/pages/file/index.html
@@ -84,8 +84,8 @@
                   errors = errors.filter(error => {
                     // console.log(error);
                     // console.log(error.nr);
-                    // console.log(!filterNumbers.includes(error.nr))
-                    return !filterNumbers.includes(error.nr);
+                    // console.log(filterNumbers.includes(error.nr))
+                    return filterNumbers.includes(error.nr);
                   }
                   );
 

--- a/pages/file/index.html
+++ b/pages/file/index.html
@@ -71,6 +71,26 @@
               fetch('errors.json')
                 .then(response => response.json())
                 .then(errors => {
+
+                  // console.log(errors);
+
+                  const urlFragment = window.location.hash.substring(1);
+                  const filterNumbers = urlFragment.split("|")
+                    .map(text => text.match(/^[a-zA-Z](\d+)/)?.[1]) // Extract number
+                    .filter(Boolean) // Remove null values
+                    .map(Number);
+                  // console.log(filterNumbers);
+
+                  errors = errors.filter(error => {
+                    // console.log(error);
+                    // console.log(error.nr);
+                    // console.log(!filterNumbers.includes(error.nr))
+                    return !filterNumbers.includes(error.nr);
+                  }
+                  );
+
+                  // console.log(errors);
+
                   // Sort errors by lnum, col, end_lnum, end_col
                   errors.sort((a, b) => {
                     if (a.lnum !== b.lnum) return a.lnum - b.lnum;

--- a/pages/main/index.html
+++ b/pages/main/index.html
@@ -39,7 +39,6 @@
 
   </div>
 
-  <!-- Filter Modal -->
   <div class="modal fade" id="filterModal" tabindex="-1" aria-labelledby="filterModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-dialog-scrollable">
       <div class="modal-content">
@@ -61,6 +60,8 @@
   </div>
 
   <script>
+    selectedErrorsStringList = "";
+
     $(document).ready(function () {
       table = $('#issuesTable').DataTable({
         stateSave: true,
@@ -85,7 +86,7 @@
             targets: 0, // Make filename clickable
             render: function (data, type, row) {
               if (type === 'display') {
-                return `<a href="${data}" target="_blank">${data}</a>`;
+                return `<a href="#" onclick="openFile('${data}'); return false;">${data}</a>`;
               }
               return data;
             }
@@ -93,6 +94,10 @@
         ]
       });
     });
+
+    function openFile(url) {
+      window.open(url + "#" + selectedErrorsStringList, "_blank");
+    }
 
     $(document).ready(function () {
       $.getJSON('errors-list.json', function (issuesList) {
@@ -130,8 +135,9 @@
         selectedErrors.push($(this).val());
       });
 
+      selectedErrorsStringList = selectedErrors.join('|')
       // Apply filter to the last column
-      table.column(3).search(selectedErrors.join('|'), true, false).draw();
+      table.column(3).search(selectedErrorsStringList, true, false).draw();
 
       // Close the modal
       $('#filterModal').modal('hide');


### PR DESCRIPTION
Fixes https://github.com/koppor/errorformat-to-html/issues/18 in a dirty way. Better something than nothing.

Better approach

1. Pass only numbers instead of whole strings
2. Hover on link in data tables should show full string

#FutureWork