### PR TITLE
Improve filtering

### DIFF
--- a/pages/file/e102.tex
+++ b/pages/file/e102.tex
@@ -1,1 +1,0 @@
-../../expltools/explcheck/testfiles/e102.tex

--- a/pages/file/index.html
+++ b/pages/file/index.html
@@ -75,17 +75,13 @@
                   // console.log(errors);
 
                   const urlFragment = window.location.hash.substring(1);
-                  const filterNumbers = urlFragment.split("|")
-                    .map(text => text.match(/^[a-zA-Z](\d+)/)?.[1]) // Extract number
-                    .filter(Boolean) // Remove null values
-                    .map(Number);
-                  // console.log(filterNumbers);
+                  const filterIdentifiers = urlFragment.split(",")
+                    .map(identifier => identifier.toLowerCase()) // Extract number
+                  // console.log(filterIdentifiers);
 
                   errors = errors.filter(error => {
-                    // console.log(error);
-                    // console.log(error.nr);
-                    // console.log(filterNumbers.includes(error.nr))
-                    return filterNumbers.includes(error.nr);
+                    let identifier = String.fromCodePoint(error.type).toLowerCase() + error.nr.toString();
+                    return filterIdentifiers.includes(identifier);
                   }
                   );
 

--- a/pages/main/index.html
+++ b/pages/main/index.html
@@ -52,7 +52,6 @@
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
           <button type="button" class="btn btn-danger" id="clearFilter">Clear Filter</button>
-          <button type="button" class="btn btn-warning" id="warningsAndErrorsFilter">Warnings and Errors</button>
           <button type="button" class="btn btn-primary" id="applyFilter">Apply Filter</button>
         </div>
       </div>
@@ -130,8 +129,6 @@
         return !$(this).hasClass('issue-type-style');
       });
     }
-
-    $('#warningsAndErrorsFilter').on('click', function() {checkWarnungsAndErrorsOnly()});
 
     function applyFilter() {
       let selectedErrors = [];

--- a/pages/main/index.html
+++ b/pages/main/index.html
@@ -137,10 +137,11 @@
       let selectedErrors = [];
 
       $('.issue-filter:checked').each(function () {
-        selectedErrors.push($(this).val());
+        let identifier = $(this).val().split(" ")[0];
+        selectedErrors.push(identifier);
       });
 
-      selectedErrorsStringList = selectedErrors.join('|')
+      selectedErrorsStringList = selectedErrors.join(',')
 
       // Apply filter to the last column
       table.column(3).search(selectedErrorsStringList, true, false).draw();


### PR DESCRIPTION
This PR makes the following changes:

1. Use comma-delimited issue identifiers to encode the current filter in detail view URLs.
2. Remove button "Warnings and Errors"

This PR also makes the following changes:

3. Remove a dangling symlink to `expltools/explcheck/testfiles/e102.tex`.
4. Use not just the issue number but also the issue type when decoding a filter from URL.

Ad 1 and 4: This should fix point 1 from https://github.com/koppor/errorformat-to-html/pull/26#issue-2856380837 and https://github.com/koppor/errorformat-to-html/issues/28#issue-2857171586.

Ad 2: In point 3 from https://github.com/koppor/errorformat-to-html/pull/26#issuecomment-2662723561, I though that we should rename the button to "Non-Style Warnings and Errors". However, that's really long and still doesn't seem very understandable to new users. Furthermore, as discussed in https://github.com/koppor/errorformat-to-html/pull/26#issuecomment-2662723561, clicking the button doesn't do much besides reverting to the defaults, which we can easily do by refreshing the page. Therefore, it seems best to just get rid of it.