### PR TITLE
Improve filtering (again)

### DIFF
--- a/pages/file/index.html
+++ b/pages/file/index.html
@@ -75,7 +75,7 @@
                   // console.log(errors);
 
                   const urlFragment = window.location.hash.substring(1);
-                  const filterIdentifiers = urlFragment.split('|')
+                  const filterIdentifiers = urlFragment.split(',')
                     .map(identifier => identifier)  // Extract identifier
                   // console.log(filterIdentifiers);
 

--- a/pages/file/index.html
+++ b/pages/file/index.html
@@ -80,7 +80,7 @@
                   // If some identifiers were given in URL fragment, use them to filter the errors
                   if(filterIdentifiers.length > 0) {
                     errors = errors.filter(error => {
-                      let identifier = String.fromCodePoint(error.type) + error.nr.toString();
+                      let identifier = `${String.fromCodePoint(error.type)}${error.nr}`;
                       return filterIdentifiers.includes(identifier);
                     });
                   }

--- a/pages/file/index.html
+++ b/pages/file/index.html
@@ -75,17 +75,13 @@
                   // console.log(errors);
 
                   const urlFragment = window.location.hash.substring(1);
-                  const filterNumbers = urlFragment.split("|")
-                    .map(text => text.match(/^[a-zA-Z](\d+)/)?.[1]) // Extract number
-                    .filter(Boolean) // Remove null values
-                    .map(Number);
-                  // console.log(filterNumbers);
+                  const filterIdentifiers = urlFragment.split(",")
+                    .map(identifier => identifier.toLowerCase()) // Extract number
+                  // console.log(filterIdentifiers);
 
                   errors = errors.filter(error => {
-                    // console.log(error);
-                    // console.log(error.nr);
-                    // console.log(filterNumbers.includes(error.nr))
-                    return filterNumbers.includes(error.nr);
+                    let identifier = String.fromCodePoint(error.type).toLowerCase() + error.nr.toString();
+                    return filterIdentifiers.includes(identifier);
                   }
                   );
 

--- a/pages/file/index.html
+++ b/pages/file/index.html
@@ -75,15 +75,15 @@
                   // console.log(errors);
 
                   const urlFragment = window.location.hash.substring(1);
-                  const filterIdentifiers = urlFragment.split(',')
-                    .map(identifier => identifier)  // Extract identifier
-                  // console.log(filterIdentifiers);
+                  const filterIdentifiers = urlFragment.split(',');
 
-                  errors = errors.filter(error => {
-                    let identifier = String.fromCodePoint(error.type) + error.nr.toString();
-                    return filterIdentifiers.includes(identifier);
+                  // If some identifiers were given in URL fragment, use them to filter the errors
+                  if(filterIdentifiers.length > 0) {
+                    errors = errors.filter(error => {
+                      let identifier = String.fromCodePoint(error.type) + error.nr.toString();
+                      return filterIdentifiers.includes(identifier);
+                    });
                   }
-                  );
 
                   // console.log(errors);
 

--- a/pages/file/index.html
+++ b/pages/file/index.html
@@ -76,11 +76,11 @@
 
                   const urlFragment = window.location.hash.substring(1);
                   const filterIdentifiers = urlFragment.split(",")
-                    .map(identifier => identifier.toLowerCase()) // Extract number
+                    .map(identifier => identifier)  // Extract identifier
                   // console.log(filterIdentifiers);
 
                   errors = errors.filter(error => {
-                    let identifier = String.fromCodePoint(error.type).toLowerCase() + error.nr.toString();
+                    let identifier = String.fromCodePoint(error.type) + error.nr.toString();
                     return filterIdentifiers.includes(identifier);
                   }
                   );

--- a/pages/file/index.html
+++ b/pages/file/index.html
@@ -78,7 +78,7 @@
                   const filterIdentifiers = urlFragment.split(',');
 
                   // If some identifiers were given in URL fragment, use them to filter the errors
-                  if(filterIdentifiers.length > 0) {
+                  if(urlFragment.length > 0) {
                     errors = errors.filter(error => {
                       let identifier = `${String.fromCodePoint(error.type)}${error.nr}`;
                       return filterIdentifiers.includes(identifier);

--- a/pages/file/index.html
+++ b/pages/file/index.html
@@ -75,7 +75,7 @@
                   // console.log(errors);
 
                   const urlFragment = window.location.hash.substring(1);
-                  const filterIdentifiers = urlFragment.split(",")
+                  const filterIdentifiers = urlFragment.split('|')
                     .map(identifier => identifier)  // Extract identifier
                   // console.log(filterIdentifiers);
 

--- a/pages/main/index.html
+++ b/pages/main/index.html
@@ -133,7 +133,7 @@
       });
 
       // Apply filter to the last column
-      table.column(3).search(selectedErrors.join('|'), true, false).invalidate().draw();
+      table.column(3).search(selectedErrors.join('|'), true, false).rows().invalidate().draw();
     }
 
     $('#applyFilter').on('click', function () {

--- a/pages/main/index.html
+++ b/pages/main/index.html
@@ -133,7 +133,7 @@
       });
 
       // Apply filter to the last column
-      table.column(3).search(selectedErrors.join('|'), true, false).draw();
+      table.column(3).search(selectedErrors.join('|'), true, false).invalidate().draw();
     }
 
     $('#applyFilter').on('click', function () {

--- a/pages/main/index.html
+++ b/pages/main/index.html
@@ -52,7 +52,6 @@
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
           <button type="button" class="btn btn-danger" id="clearFilter">Clear Filter</button>
-          <button type="button" class="btn btn-warning" id="warningsAndErrorsFilter">Warnings and Errors</button>
           <button type="button" class="btn btn-primary" id="applyFilter">Apply Filter</button>
         </div>
       </div>
@@ -130,8 +129,6 @@
         return !$(this).hasClass('issue-type-style');
       });
     }
-
-    $('#warningsAndErrorsFilter').on('click', function() {checkWarnungsAndErrorsOnly()});
 
     function applyFilter() {
       let selectedErrors = [];

--- a/pages/main/index.html
+++ b/pages/main/index.html
@@ -96,7 +96,7 @@
     });
 
     function openFile(url) {
-      window.open(url + "#" + selectedErrorsStringList, "_blank");
+      window.open(url + "#" + selectedErrors.join(','), "_blank");
     }
 
     $(document).ready(function () {

--- a/pages/main/index.html
+++ b/pages/main/index.html
@@ -137,10 +137,11 @@
       let selectedErrors = [];
 
       $('.issue-filter:checked').each(function () {
-        selectedErrors.push($(this).val());
+        let identifier = $(this).val().split(" ")[0];
+        selectedErrors.push(identifier);
       });
 
-      selectedErrorsStringList = selectedErrors.join('|')
+      selectedErrorsStringList = selectedErrors.join(',')
 
       // Apply filter to the last column
       table.column(3).search(selectedErrorsStringList, true, false).draw();

--- a/pages/main/index.html
+++ b/pages/main/index.html
@@ -105,7 +105,7 @@
                     ${issue}
                 </label>
             </div>
-        `;
+          `;
           checkboxContainer.append(checkbox);
         });
 

--- a/pages/main/index.html
+++ b/pages/main/index.html
@@ -86,7 +86,7 @@
             targets: 0, // Make filename clickable
             render: function (data, type, row) {
               if (type === 'display') {
-                return `<a href="#" onclick="openFile('${data}'); return false;">${data}</a>`;
+                return `<a href="${data}#${selectedErrors.join(',')}" target="_blank">${data}</a>`;
               }
               return data;
             }
@@ -94,10 +94,6 @@
         ]
       });
     });
-
-    function openFile(url) {
-      window.open(url + "#" + selectedErrors.join(','), "_blank");
-    }
 
     $(document).ready(function () {
       $.getJSON('errors-list.json', function (issuesList) {

--- a/pages/main/index.html
+++ b/pages/main/index.html
@@ -69,7 +69,16 @@
           dataSrc: '' // Data is a direct array at the root of the JSON
         },
         columns: [
-          { data: 'filename', title: 'Filename' },
+          {
+            data: 'filename',
+            title: 'Filename',
+            render: function (data, type, row) { // Make filename clickable
+              if (type === 'display') {
+                return `<a href="${data}#${selectedErrors.join(',')}" target="_blank">${data}</a>`;
+              }
+              return data;
+            }
+          },
           { data: 'errors', title: '# Errors', defaultContent: 0 },
           { data: 'warnings', title: '# Warnings', defaultContent: 0 },
           {
@@ -79,17 +88,6 @@
             title: 'Issue Identifiers',
             searchable: true,
             visible: false
-          }
-        ],
-        columnDefs: [
-          {
-            targets: 0, // Make filename clickable
-            render: function (data, type, row) {
-              if (type === 'display') {
-                return `<a href="${data}#${selectedErrors.join(',')}" target="_blank">${data}</a>`;
-              }
-              return data;
-            }
           }
         ]
       });

--- a/pages/main/index.html
+++ b/pages/main/index.html
@@ -59,7 +59,7 @@
   </div>
 
   <script>
-    selectedErrorsStringList = "";
+    const selectedErrors = [];
 
     $(document).ready(function () {
       table = $('#issuesTable').DataTable({
@@ -132,17 +132,14 @@
     }
 
     function applyFilter() {
-      let selectedErrors = [];
-
+      selectedErrors.length = 0;
       $('.issue-filter:checked').each(function () {
         let identifier = $(this).val().split(" ")[0];
         selectedErrors.push(identifier);
       });
 
-      selectedErrorsStringList = selectedErrors.join('|');
-
       // Apply filter to the last column
-      table.column(3).search(selectedErrorsStringList, true, false).draw();
+      table.column(3).search(selectedErrors.join('|'), true, false).draw();
     }
 
     $('#applyFilter').on('click', function () {

--- a/pages/main/index.html
+++ b/pages/main/index.html
@@ -139,7 +139,7 @@
         selectedErrors.push(identifier);
       });
 
-      selectedErrorsStringList = selectedErrors.join('|')
+      selectedErrorsStringList = selectedErrors.join('|');
 
       // Apply filter to the last column
       table.column(3).search(selectedErrorsStringList, true, false).draw();

--- a/pages/main/index.html
+++ b/pages/main/index.html
@@ -74,8 +74,9 @@
           { data: 'warnings', title: '# Warnings', defaultContent: 0 },
           {
             data: function (row) {
-              return row.lines.join(' ');
+              return row.identifiers.join(' ');
             },
+            title: 'Issue Identifiers',
             searchable: true,
             visible: false
           }
@@ -138,7 +139,7 @@
         selectedErrors.push(identifier);
       });
 
-      selectedErrorsStringList = selectedErrors.join(',')
+      selectedErrorsStringList = selectedErrors.join('|')
 
       // Apply filter to the last column
       table.column(3).search(selectedErrorsStringList, true, false).draw();

--- a/scripts/create-errors-summarized.py
+++ b/scripts/create-errors-summarized.py
@@ -12,7 +12,7 @@ with open('errors.json', 'r') as file:
 pattern = r"/tmp/texlive/usr/local/texlive/\d{4}/"
 
 # Dictionary to store combined results
-summarized_data = defaultdict(lambda: {'lines': [], 'identifiers': [], 'types': defaultdict(int)})
+summarized_data = defaultdict(lambda: {'lines': [], 'identifiers': set(), 'types': defaultdict(int)})
 
 # Type mapping
 type_mapping = {
@@ -35,7 +35,7 @@ for entry in data:
     cleaned_lines = [re.sub(pattern, '', line) for line in entry['lines']]
 
     summarized_data[filename]['lines'].extend(cleaned_lines)
-    summarized_data[filename]['identifiers'].append(f"{chr(entry['type'])}{entry['nr']}")
+    summarized_data[filename]['identifiers'].add(f"{chr(entry['type'])}{entry['nr']}")
     type_key = type_mapping.get(str(entry['type']), str(entry['type']))
     summarized_data[filename]['types'][type_key] += 1
 
@@ -51,7 +51,7 @@ for filename, details in summarized_data.items():
     output_data.append({
         'filename': filename,
         'lines': details['lines'],
-        'identifiers': details['identifiers'],
+        'identifiers': sorted(details['identifiers']),
         **details['types']  # Unpack type counts
     })
 

--- a/scripts/create-errors-summarized.py
+++ b/scripts/create-errors-summarized.py
@@ -12,7 +12,7 @@ with open('errors.json', 'r') as file:
 pattern = r"/tmp/texlive/usr/local/texlive/\d{4}/"
 
 # Dictionary to store combined results
-summarized_data = defaultdict(lambda: {'lines': [], 'types': defaultdict(int)})
+summarized_data = defaultdict(lambda: {'lines': [], 'identifiers': [], 'types': defaultdict(int)})
 
 # Type mapping
 type_mapping = {
@@ -35,6 +35,7 @@ for entry in data:
     cleaned_lines = [re.sub(pattern, '', line) for line in entry['lines']]
 
     summarized_data[filename]['lines'].extend(cleaned_lines)
+    summarized_data[filename]['identifiers'].append(f"{chr(entry['type'])}{entry['nr']}")
     type_key = type_mapping.get(str(entry['type']), str(entry['type']))
     summarized_data[filename]['types'][type_key] += 1
 
@@ -50,6 +51,7 @@ for filename, details in summarized_data.items():
     output_data.append({
         'filename': filename,
         'lines': details['lines'],
+        'identifiers': details['identifiers'],
         **details['types']  # Unpack type counts
     })
 

--- a/scripts/create-errors-summarized.py
+++ b/scripts/create-errors-summarized.py
@@ -18,6 +18,7 @@ summarized_data = defaultdict(lambda: {'lines': [], 'types': defaultdict(int)})
 type_mapping = {
     '101': 'errors',
     '115': 'warnings',
+    '115': 'errors',
     '119': 'warnings'
 }
 


### PR DESCRIPTION
This PR makes the following changes:

1. Use comma-delimited issue identifiersto encode the current filter in URL fragments.
2. Show full URLs when we hover over hyperlinks in list view.
3. Remove button "Warnings and Errors".

Ad 1 and 2: These should fix points 1 and 2 from https://github.com/koppor/errorformat-to-html/pull/26#issue-2856380837 and https://github.com/koppor/errorformat-to-html/issues/28#issue-2857171586 and close #28.

Ad 3: In point 3 from https://github.com/koppor/errorformat-to-html/pull/26#issuecomment-2662723561, I though that we should rename the button to "Non-Style Warnings and Errors". However, that's really long and still doesn't seem very understandable to new users. Furthermore, as discussed in https://github.com/koppor/errorformat-to-html/pull/26#issuecomment-2662723561, clicking the button doesn't do much besides reverting to the defaults, which we can easily do by refreshing the page. Therefore, it seemed better to just get rid of it for now.

I previously did these changes in #30 but they turned out to be breaking. Therefore, I reverted them from `main` and reopened the PR here! @koppor, please feel free to force-push branch `main` to commit 03a130203bfa53d0d3e643b0e0fa66a6b13cc758 or 18efb09bab8231d959abe97fd4e7c2d1055c1c6e if you'd like clean Git history. I am sorry about that.