### PR TITLE
Use `--files-from` instead of `find -exec {} +`

### DIFF
--- a/.github/workflows/generate-page.yml
+++ b/.github/workflows/generate-page.yml
@@ -119,12 +119,13 @@ jobs:
           set -e
 
           timeout 50m bash -c '
-            find /tmp/texlive -type f -exec \
-              docker run --rm -v "/tmp/texlive:/tmp/texlive" ghcr.io/witiko/expltools/explcheck \
-                --porcelain \
-                --config-file=/opt/expltools/.explcheckrc \
-                --error-format="%f:%l:%c:%e:%k: %t%n %m" \
-                {} + | sponge -a errors.txt
+            find /tmp/texlive -type f | sponge /tmp/texlive/files.txt
+            docker run --rm -v "/tmp/texlive:/tmp/texlive" ghcr.io/witiko/expltools/explcheck \
+              --porcelain \
+              --config-file=/opt/expltools/.explcheckrc \
+              --files-from=/tmp/texlive/files.txt \
+              --error-format="%f:%l:%c:%e:%k: %t%n %m" \
+              | sponge -a errors.txt
           ' || echo "Process terminated after 50 minutes."
 
           errorformat -w jsonl '%f:%l:%c:%e:%k: %t%n %m' < errors.txt > errors.list


### PR DESCRIPTION
Since https://github.com/Witiko/expltools/pull/131, _explcheck_ has supported inter-file dependencies: Files that originate from the same directory are grouped and missing definitions/uses/etc. are only reported when they are missing across the entire group of files.

Currently, _explcheck-issues_ uses `find -exec {} +` to execute _explcheck_ potentially many times if there are many files to check. Since files at the maximum argument number boundaries are not correctly grouped even if they originate from the same directory, this may affect correctness. To this end, https://github.com/Witiko/expltools/pull/131 has introduced the command-line option `--files-from`, which allows the files to be read from a text file and where there is no restriction on the number of files.

This PR replaces `find -exec {} +` with the new command-line option `--files-from`.